### PR TITLE
manage.py syncdb -> manage.py migrate

### DIFF
--- a/content/admin-processes.md
+++ b/content/admin-processes.md
@@ -3,7 +3,7 @@
 
 The [process formation](/concurrency) is the array of processes that are used to do the app's regular business (such as handling web requests) as it runs.  Separately, developers will often wish to do one-off administrative or maintenance tasks for the app, such as:
 
-* Running database migrations (e.g. `manage.py syncdb` in Django, `rake db:migrate` in Rails).
+* Running database migrations (e.g. `manage.py migrate` in Django, `rake db:migrate` in Rails).
 * Running a console (also known as a [REPL](http://en.wikipedia.org/wiki/Read-eval-print_loop) shell) to run arbitrary code or inspect the app's models against the live database.  Most languages provide a REPL by running the interpreter without any arguments (e.g. `python` or `erl`) or in some cases have a separate command (e.g. `irb` for Ruby, `rails console` for Rails).
 * Running one-time scripts committed into the app's repo (e.g. `php scripts/fix_bad_records.php`).
 


### PR DESCRIPTION
syncdb is deprecated as of the now released django 1.7