### PR TITLE
Fix broken markup on main page

### DIFF
--- a/views/home.erb
+++ b/views/home.erb
@@ -5,7 +5,7 @@
 </section>
 
 <section class="concrete">
-  <article><%= render_markdown('toc') %><article>
+  <article><%= render_markdown('toc') %></article>
 </section>
 
 


### PR DESCRIPTION
I noticed that the markup on [12factor.net](http://12factor.net/) contains an element that doesn't get closed properly. Firefox (and I guess a lot of more browsers) are still able to render the markup, so it's not a big deal.