### PR TITLE
add a space between the title and the traduction mention

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
 
-  <title>The Twelve-Factor App<%= I18n.t(:translation) %></title>
+  <title>The Twelve-Factor App <%= I18n.t(:translation) %></title>
   <meta name="description" content="A methodology for building modern, scalable, maintainable software-as-a-service apps.">
   <meta name="author" content="Adam Wiggins">
 


### PR DESCRIPTION
That will add an unnecessary space at the end of the title in english. But all browsers trim them those days.