### PR TITLE
Link and add more contributors

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -27,7 +27,7 @@ Daigle, Mark Imbriaco, Keith Rarick, Will Leinweber, Jesper Jørgensen, James
 Ward, Adam Seligman, Phil Hagelberg, Jon Mountjoy, Matthew Turland, Daniel
 Jomphe, Mattt Thompson, Anand Narasimhan, Lucas Fais, Pete Hodgson
 
-Translations and edits by:  https://github.com/mahnunchik, https://github.com/francescomalatesta, https://github.com/astralhpi, https://github.com/liangshan, https://github.com/orangain, https://github.com/Keirua, Clément Camin, Bob Marteen, https://github.com/dmathieu, https://github.com/fernandes, https://github.com/gwmoura, https://github.com/lfilho and [more](https://github.com/heroku/12factor/graphs/contributors).
+Translations and edits by: [@mahnunchik](https://github.com/mahnunchik), [@francescomalatesta](https://github.com/francescomalatesta), [@astralhpi](https://github.com/astralhpi), [@liangshan](https://github.com/liangshan), [@orangain](https://github.com/orangain), [@Keirua](https://github.com/Keirua), Clément Camin, Bob Marteen, [@dmathieu](https://github.com/dmathieu), [@fernandes](https://github.com/fernandes), [@gwmoura](https://github.com/gwmoura), [@lfilho](https://github.com/lfilho) and [more](https://github.com/heroku/12factor/graphs/contributors).
 
 Released under the MIT License: http://www.opensource.org/licenses/mit-license.php
 


### PR DESCRIPTION
In this PR:

- Add brazillian portuguese translators to the contributors list
- Link all contributors to their profile