### PR TITLE
Provide encoding for reading localization files.

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -35,7 +35,7 @@ end
 
 helpers do
   def render_markdown(file)
-    markdown = File.read("content/#{I18n.locale}/#{file}.md")
+    markdown = File.read("content/#{I18n.locale}/#{file}.md", :encoding => 'utf-8')
     Maruku.new(markdown).to_html
   rescue Errno::ENOENT
     puts "No content for #{I18n.locale}/#{file}, skipping"


### PR DESCRIPTION
This change solves problem with `Encoding::CompatibilityError` while opening site on localhost, Windows platform.