### PR TITLE
Add space around navigation links

### DIFF
--- a/public/css/screen.css
+++ b/public/css/screen.css
@@ -124,6 +124,7 @@ nav #prev {
   float: left;
 }
 nav #next a, nav #prev a {
+  display: block;
   font-size: 19pt;
   text-decoration: none;
   color: #000;


### PR DESCRIPTION
Bottom navigation was too close to translation links due to inline elements not respecting padding. Changing display property of navigation links to block solves the issue.