### PR TITLE
typo: "build stage fetches and vendors [deps]"

### DIFF
--- a/content/en/build-release-run.md
+++ b/content/en/build-release-run.md
@@ -3,7 +3,7 @@
 
 A [codebase](./codebase) is transformed into a (non-development) deploy through three stages:
 
-* The *build stage* is a transform which converts a code repo into an executable bundle known as a *build*.  Using a version of the code at a commit specified by the deployment process, the build stage fetches and vendors [dependencies](./dependencies) and compiles binaries and assets.
+* The *build stage* is a transform which converts a code repo into an executable bundle known as a *build*.  Using a version of the code at a commit specified by the deployment process, the build stage fetches vendors [dependencies](./dependencies) and compiles binaries and assets.
 * The *release stage* takes the build produced by the build stage and combines it with the deploy's current [config](./config).  The resulting *release* contains both the build and the config and is ready for immediate execution in the execution environment.
 * The *run stage* (also known as "runtime") runs the app in the execution environment, by launching some set of the app's [processes](./processes) against a selected release.
 


### PR DESCRIPTION
Perhaps it's meant to be "build stage fetches _all_ vendors [deps]"?
