### PR TITLE
Update title casing for en background services

### DIFF
--- a/content/en/backing-services.md
+++ b/content/en/backing-services.md
@@ -1,4 +1,4 @@
-## IV. Backing Services
+## IV. Backing services
 ### Treat backing services as attached resources
 
 A *backing service* is any service the app consumes over the network as part of its normal operation.  Examples include datastores (such as [MySQL](http://dev.mysql.com/) or [CouchDB](http://couchdb.apache.org/)), messaging/queueing systems (such as [RabbitMQ](http://www.rabbitmq.com/) or [Beanstalkd](http://kr.github.com/beanstalkd/)), SMTP services for outbound email (such as [Postfix](http://www.postfix.org/)), and caching systems (such as [Memcached](http://memcached.org/)).


### PR DESCRIPTION
Other titles are in Sentence case, but backing services got away with Title Case. Burn the heretic.