### PR TITLE
Use HTTPS for 12factor.net

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 The Twelve-Factor App
 =====================
 
-Source for the content app running at: http://www.12factor.net/
+Source for the content app running at: https://www.12factor.net/
 
 Development
 -----------


### PR DESCRIPTION
I would love to submit this as an issue, but the repo doesn't accept issues. Is there a particular reason for this, or is it because it's a fork and issues haven't been enabled?

Running on HTTP makes the site vulnerable to Man In The Middle attacks. [Let's Encrypt](https://letsencrypt.org/) has made security through HTTPS both free and easy to configure. Why not use it?

I don't know the infrastructure behind http://12factor.net, but DigitalOcean has a [brilliant guide on configuring HTTPS with Let's Encrypt and nginx](https://www.digitalocean.com/community/tutorials/how-to-secure-nginx-with-let-s-encrypt-on-ubuntu-14-04).

Is there any way I can help secure 12factor.net with HTTPS?