### PR TITLE
Correcting spanish translation for 'disposability'

### DIFF
--- a/content/es/disposability.md
+++ b/content/es/disposability.md
@@ -1,7 +1,7 @@
-## IX. Disponibilidad
+## IX. Desechabilidad
 ### Hacer el sistema más robusto intentando conseguir inicios rápidos y finalizaciones seguras
 
-**Los [procesos](./processes) de las aplicaciones "twelve-factor" están *disponibles*, lo que significa que pueden iniciarse o finalizarse en el momento que sea necesario.** Esto permite un escalado rápido y flexible, un despliegue rápido del [código](./codebase) y de los cambios de las [configuraciones](./config), y despliegues más robustos en producción.
+**Los [procesos](./processes) de las aplicaciones "twelve-factor" son *desechables*, lo que significa que pueden iniciarse o finalizarse en el momento que sea necesario.** Esto permite un escalado rápido y flexible, un despliegue rápido del [código](./codebase) y de los cambios de las [configuraciones](./config), y despliegues más robustos en producción.
 
 Los procesos deberían intentar conseguir **minimizar el tiempo de arranque**. En el mejor de los casos, un proceso necesita unos pocos segundos desde que se ejecuta el mandato hasta que arranca y está preparado para recibir peticiones o trabajos. Mejorar el tiempo de arranque proporciona mayor agilidad en el proceso de [distribución](./build-release-run) y escalado; y lo hace más robusto, porque el gestor de procesos puede mover procesos de forma segura entre máquinas físicas más fácilmente.
 

--- a/content/es/toc.md
+++ b/content/es/toc.md
@@ -25,7 +25,7 @@ Twelve Factors
 ## [VIII. Concurrencia](./concurrency)
 ### Escalar mediante el modelo de procesos
 
-## [IX. Disponibilidad](./disposability)
+## [IX. Desechabilidad](./disposability)
 ### Hacer el sistema más robusto intentando conseguir inicios rápidos y finalizaciones seguras
 
 ## [X. Paridad en desarrollo y producción](./dev-prod-parity)


### PR DESCRIPTION
Current version translates disposability as _disponibilidad_. This is incorrect since _disponibilidad_ actually means availability, and that is not the intent of the original text in english. Apps being disposable is a means to achieve availability, but its not the same. 

I have replaced _disponibilidad_ with the proper word: desechabilidad.