### PR TITLE
Update link to MIT license in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -29,5 +29,5 @@ Jomphe, Mattt Thompson, Anand Narasimhan, Lucas Fais, Pete Hodgson
 
 Translations and edits by: [@sigerello](https://github.com/sigerello), [@mahnunchik](https://github.com/mahnunchik), [@francescomalatesta](https://github.com/francescomalatesta), [@astralhpi](https://github.com/astralhpi), [@liangshan](https://github.com/liangshan), [@orangain](https://github.com/orangain), [@Keirua](https://github.com/Keirua), Clément Camin, Bob Marteen, [@dmathieu](https://github.com/dmathieu), [@fernandes](https://github.com/fernandes), [@gwmoura](https://github.com/gwmoura), [@lfilho](https://github.com/lfilho), [@Arturszott](https://github.com/Arturszott), [@melikeyurtoglu](https://github.com/melikeyurtoglu) and [more](https://github.com/heroku/12factor/graphs/contributors).
 
-Released under the MIT License: http://www.opensource.org/licenses/mit-license.php
-
+Released under the MIT License:
+https://opensource.org/licenses/MIT


### PR DESCRIPTION
Fixes https://github.com/heroku/12factor/issues/176