### PR TITLE
Change HTML lang attribute to equal current locale

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang=<%= I18n.locale %>>
 <head>
   <meta charset="utf-8">
 


### PR DESCRIPTION
I was looking at the website and noticed that the HTML lang is hard-coded to "en". Submitting a pull request with a minor adjustment.