### PR TITLE
For better readability changed config -> configuration, app -> application 

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
-The Twelve-Factor App
-=====================
+The Twelve-Factor Application
+=============================
 
-Source for the content app running at: https://12factor.net/
+Source for the content application running at: https://12factor.net/
 
 Development
 -----------

--- a/content/en/config.md
+++ b/content/en/config.md
@@ -7,9 +7,9 @@ An application's *configuration* is everything that is likely to vary between [d
 * Credentials to external services such as Amazon S3 or Twitter
 * Per-deploy values such as the canonical hostname for the deploy
 
-Apps sometimes store configuration as constants in the code.  This is a violation of twelve-factor, which requires **strict separation of configuration from code**.  Configuration varies substantially across deploys, code does not.
+Applications sometimes store configuration as constants in the code.  This is a violation of twelve-factor, which requires **strict separation of configuration from code**.  Configuration varies substantially across deploys, code does not.
 
-A litmus test for whether an app has all configuration correctly factored out of the code is whether the codebase could be made open source at any moment, without compromising any credentials.
+A litmus test for whether an application has all configuration correctly factored out of the code is whether the codebase could be made open source at any moment, without compromising any credentials.
 
 Note that this definition of "configuration" does **not** include internal application configuration, such as `configuration/routes.rb` in Rails, or how [code modules are connected](http://docs.spring.io/spring/docs/current/spring-framework-reference/html/beans.html) in [Spring](http://spring.io/).  This type of configuration does not vary between deploys, and so is best done in the code.
 
@@ -17,6 +17,6 @@ Another approach to configuration is the use of configuration files which are no
 
 **The twelve-factor application stores configuration in *environment variables*** (often shortened to *env vars* or *env*).  Environment variables are easy to change between deploys without changing any code; unlike configuration files, there is little chance of them being checked into the code repo accidentally; and unlike custom configuration files, or other config mechanisms such as Java System Properties, they are a language- and OS-agnostic standard.
 
-Another aspect of configuration management is grouping.  Sometimes apps batch configuration into named groups (often called "environments") named after specific deploys, such as the `development`, `test`, and `production` environments in Rails.  This method does not scale cleanly: as more deploys of the app are created, new environment names are necessary, such as `staging` or `qa`.  As the project grows further, developers may add their own special environments like `joes-staging`, resulting in a combinatorial explosion of configuration which makes managing deploys of the app very brittle.
+Another aspect of configuration management is grouping.  Sometimes applications batch configuration into named groups (often called "environments") named after specific deploys, such as the `development`, `test`, and `production` environments in Rails.  This method does not scale cleanly: as more deploys of the app are created, new environment names are necessary, such as `staging` or `qa`.  As the project grows further, developers may add their own special environments like `joes-staging`, resulting in a combinatorial explosion of configuration which makes managing deploys of the app very brittle.
 
-In a twelve-factor application, environment variable are granular controls, each fully orthogonal to other env vars.  They are never grouped together as "environments", but instead are independently managed for each deploy.  This is a model that scales up smoothly as the app naturally expands into more deploys over its lifetime.
+In a twelve-factor application, environment variable are granular controls, each fully orthogonal to other env vars.  They are never grouped together as "environments", but instead are independently managed for each deploy.  This is a model that scales up smoothly as the application naturally expands into more deploys over its lifetime.

--- a/content/en/config.md
+++ b/content/en/config.md
@@ -1,22 +1,22 @@
-## III. Config
-### Store config in the environment
+## III. Configuration
+### Store configuration in the environment
 
-An app's *config* is everything that is likely to vary between [deploys](./codebase) (staging, production, developer environments, etc).  This includes:
+An application's *configuration* is everything that is likely to vary between [deploys](./codebase) (staging, production, developer environments, etc).  This includes:
 
 * Resource handles to the database, Memcached, and other [backing services](./backing-services)
 * Credentials to external services such as Amazon S3 or Twitter
 * Per-deploy values such as the canonical hostname for the deploy
 
-Apps sometimes store config as constants in the code.  This is a violation of twelve-factor, which requires **strict separation of config from code**.  Config varies substantially across deploys, code does not.
+Apps sometimes store configuration as constants in the code.  This is a violation of twelve-factor, which requires **strict separation of configuration from code**.  Configuration varies substantially across deploys, code does not.
 
-A litmus test for whether an app has all config correctly factored out of the code is whether the codebase could be made open source at any moment, without compromising any credentials.
+A litmus test for whether an app has all configuration correctly factored out of the code is whether the codebase could be made open source at any moment, without compromising any credentials.
 
-Note that this definition of "config" does **not** include internal application config, such as `config/routes.rb` in Rails, or how [code modules are connected](http://docs.spring.io/spring/docs/current/spring-framework-reference/html/beans.html) in [Spring](http://spring.io/).  This type of config does not vary between deploys, and so is best done in the code.
+Note that this definition of "configuration" does **not** include internal application configuration, such as `configuration/routes.rb` in Rails, or how [code modules are connected](http://docs.spring.io/spring/docs/current/spring-framework-reference/html/beans.html) in [Spring](http://spring.io/).  This type of configuration does not vary between deploys, and so is best done in the code.
 
-Another approach to config is the use of config files which are not checked into revision control, such as `config/database.yml` in Rails.  This is a huge improvement over using constants which are checked into the code repo, but still has weaknesses: it's easy to mistakenly check in a config file to the repo; there is a tendency for config files to be scattered about in different places and different formats, making it hard to see and manage all the config in one place.  Further, these formats tend to be language- or framework-specific.
+Another approach to configuration is the use of configuration files which are not checked into revision control, such as `config/database.yml` in Rails.  This is a huge improvement over using constants which are checked into the code repo, but still has weaknesses: it's easy to mistakenly check in a configuration file to the repo; there is a tendency for configuration files to be scattered about in different places and different formats, making it hard to see and manage all the configuration in one place.  Further, these formats tend to be language- or framework-specific.
 
-**The twelve-factor app stores config in *environment variables*** (often shortened to *env vars* or *env*).  Env vars are easy to change between deploys without changing any code; unlike config files, there is little chance of them being checked into the code repo accidentally; and unlike custom config files, or other config mechanisms such as Java System Properties, they are a language- and OS-agnostic standard.
+**The twelve-factor application stores configuration in *environment variables*** (often shortened to *env vars* or *env*).  Environment variables are easy to change between deploys without changing any code; unlike configuration files, there is little chance of them being checked into the code repo accidentally; and unlike custom configuration files, or other config mechanisms such as Java System Properties, they are a language- and OS-agnostic standard.
 
-Another aspect of config management is grouping.  Sometimes apps batch config into named groups (often called "environments") named after specific deploys, such as the `development`, `test`, and `production` environments in Rails.  This method does not scale cleanly: as more deploys of the app are created, new environment names are necessary, such as `staging` or `qa`.  As the project grows further, developers may add their own special environments like `joes-staging`, resulting in a combinatorial explosion of config which makes managing deploys of the app very brittle.
+Another aspect of configuration management is grouping.  Sometimes apps batch configuration into named groups (often called "environments") named after specific deploys, such as the `development`, `test`, and `production` environments in Rails.  This method does not scale cleanly: as more deploys of the app are created, new environment names are necessary, such as `staging` or `qa`.  As the project grows further, developers may add their own special environments like `joes-staging`, resulting in a combinatorial explosion of configuration which makes managing deploys of the app very brittle.
 
-In a twelve-factor app, env vars are granular controls, each fully orthogonal to other env vars.  They are never grouped together as "environments", but instead are independently managed for each deploy.  This is a model that scales up smoothly as the app naturally expands into more deploys over its lifetime.
+In a twelve-factor application, environment variable are granular controls, each fully orthogonal to other env vars.  They are never grouped together as "environments", but instead are independently managed for each deploy.  This is a model that scales up smoothly as the app naturally expands into more deploys over its lifetime.


### PR DESCRIPTION
For better readability changed config -> configuration, app -> application.
If it is approved, I volunteer to change every instance of other words in all of the project.

When writing a full English sentence, it would be ready for both native and non-native English reader to understand the meaning easily and quickly.

Examples:
env -> environment
app -> application
config -> configuration

thanks with gratitude,
Subbu