### PR TITLE
Minor addition to pt_br/codebase.md

### DIFF
--- a/content/pt_br/codebase.md
+++ b/content/pt_br/codebase.md
@@ -3,7 +3,7 @@
 
 Uma aplicação 12 fatores é sempre rastreada em um sistema de controle de versão, como [Git](http://git-scm.com/), [Mercurial](https://www.mercurial-scm.org/), ou [Subversion](http://subversion.apache.org/). Uma cópia da base de dados do rastreamento de revisões é conhecido como *repositório de código*, normalmente abreviado como *repositório* ou *repo*.
 
-Uma *base de código* é um único repo (em um sistema de controle de versão centralizado como Subversion), ou uma série de repositórios que compartilham um registro raiz.
+Uma *base de código* é um único repo (em um sistema de controle de versão centralizado como Subversion), ou uma série de repositórios que compartilham um registro raiz (no caso de sistemas de controle descentralizados, como o Git).
 
 ![Uma base de código para vários deploys](/images/codebase-deploys.png)
 


### PR DESCRIPTION
Added missing sentence about descentralized revision control systems, present in the english version in parentheses: "(in a decentralized revision control system like Git)".