### PR TITLE
Correct locale loading

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec ruby web.rb -p $PORT
+web: ruby web.rb -p $PORT

--- a/web.rb
+++ b/web.rb
@@ -6,7 +6,7 @@ require 'rack/ssl-enforcer'
 configure do
   use Rack::SslEnforcer if ENV['FORCE_SSL']
   I18n.enforce_available_locales = true
-  I18n.load_path = Dir[File.join(settings.root, 'locales', '*.yml')]
+  I18n.load_path = Dir[File.join('locales', '*.yml')]
   I18n.backend.load_translations
   I18n.default_locale = :en
 end

--- a/web.rb
+++ b/web.rb
@@ -6,7 +6,7 @@ require 'rack/ssl-enforcer'
 configure do
   use Rack::SslEnforcer if ENV['FORCE_SSL']
   I18n.enforce_available_locales = true
-  I18n.load_path = Dir[File.join('locales', '*.yml')]
+  I18n.load_path = Dir[File.join(File.dirname(__FILE__), 'locales', '*.yml')]
   I18n.backend.load_translations
   I18n.default_locale = :en
 end


### PR DESCRIPTION
After upgrading to Ruby 3.3, this path stopped getting populated correctly, and as such, we no longer had any defined localizations. It wasn't reproducible locally, so was missed in recent updates.

Also dropped `bundle exec` from the `Procfile` – running the app in that context is causing an error somewhere in the chain that is being swallowed; `bundle` is exiting `0` and not being helpful. There really isn't a _great_ reason to `bundle exec` a Sinatra app that I can think of... generally one uses `ruby` directly or through Rack with `rackup`. 