### PR TITLE
fix(deps): bump rack-session to >=2.1.2 (GHSA-33qg-7wpp-89cq)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
       rack (>= 3.0.0, < 4)
-    rack-session (2.1.1)
+    rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
     rack-ssl-enforcer (0.2.9)
@@ -62,4 +62,4 @@ RUBY VERSION
    ruby 3.3.5p100
 
 BUNDLED WITH
-   2.4.10
+   2.5.16


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/f9f4ec17-d8db-42f8-bf58-dcda12a12663" width="24" align="top"> **3PP Grackle** (automated dependency triage -- Frontend DX) -- **babysit** _(AT run `cc80d33f`)_

## Summary

Fixes 1 **CRITICAL** severity 3PP vulnerability in `rack-session` (GHSA-33qg-7wpp-89cq).

`rack-session` prior to 2.1.2 is affected by a session-fixation issue: when an application calls `Rack::Session::Abstract::SessionHash#destroy` without rotating session identifiers, the underlying session store can leave the old session ID usable by an attacker. Upgrading to 2.1.2 includes the upstream fix that ensures destroyed sessions cannot be reused.

**Production risk:** Runtime
`rack-session` is reachable in production: it is a transitive dependency of `sinatra`, which serves the 12factor application's HTTP surface. Any request path that exercises session handling touches this code.

**Strategy:** upgrade-transitive

## Changes

### Gemfile

No manifest changes. `rack-session` is not a direct dependency; it is pulled in transitively by `sinatra`. Bumping via a scoped `bundle update` avoids touching the top-level Gemfile.

### Gemfile.lock

Re-resolved `rack-session` from `2.1.1` to `2.1.2`:

```
-    rack-session (2.1.1)
+    rack-session (2.1.2)
```

`BUNDLED WITH` also advanced from `2.4.10` to `2.5.16` as a side effect of running `bundle update` under the local Bundler. This is a tooling-version bump, not a dependency change.

**Why `bundle update rack-session --conservative` (transitive upgrade) rather than an override?**
`rack-session` is an indirect dependency via `sinatra`. Bundler's dependency resolver will honor `sinatra`'s declared range and pull the highest compatible `rack-session` release (`2.1.2`) without touching any other gem. `--conservative` prevents Bundler from also upgrading sibling gems that happen to share a constraint graph with `rack-session`, keeping the lockfile delta minimal (one line of actual dependency change). Ruby/Bundler does not have a first-class override mechanism equivalent to `pnpm.overrides` or `resolutions`; a scoped `bundle update` is the idiomatic way to lift a single transitive.

### Lockfile

- `Gemfile.lock` re-resolved to pull in the patched `rack-session` version.

## Risk Classification

| Classification | When to use | PR copy |
|----------------|-------------|---------|
| Runtime | Vulnerable package reaches the production code path (any path from a `dependencies` entry) | "This vulnerability is reachable in production. Priority: HIGH." |

This vulnerability is reachable in production. Priority: HIGH.

## Vulnerabilities Fixed

| CVE/GHSA | Package | Severity | Fixed Version |
|----------|---------|----------|---------------|
| GHSA-33qg-7wpp-89cq | rack-session | critical | >=2.1.2 |

## How to Test

Local verification on the PR branch:

```bash
# 1. Confirm the lockfile now pins the patched version.
grep -n 'rack-session' Gemfile.lock
# Expected: rack-session (2.1.2)

# 2. Install the locked dependency set.
bundle install

# 3. Sanity-check the Sinatra entry point parses.
bundle exec ruby -c web.rb

# 4. Boot the app and exercise a session-bearing route (any page under views/).
bundle exec rackup -p 5000
# In another shell:
curl -i http://localhost:5000/
# Confirm a `Set-Cookie: rack.session=...` header is issued and the app responds 200.
```

Affected surface to smoke-test:

- Any route that reads or writes `session[...]` in `web.rb` or downstream handlers.
- Language/locale switching flows that rely on session persistence across requests.

## Validation

Validation is a before/after comparison. Pre-existing environmental notes are captured so they are not mistaken for regressions introduced by this PR.

- Install (baseline / post-fix): PASS / PASS
- Tests (baseline / post-fix): PASS / PASS (no test suite is defined in this repo; `bundle check` is the install-time gate)
- Lint (baseline / post-fix): N/A (no lint script configured)
- Build (baseline / post-fix): N/A (Sinatra app; no build step)

**Environmental note (not a regression):**
- Re-running `bundle check` on the rebody pass reported `Your Ruby version is 3.2.2, but your Gemfile specified 3.3.5` because the local rebody environment only has Ruby 3.2.2 installed. This is an environmental mismatch, not a regression of the fix. The original fix run was performed under Ruby 3.3.5 and reported `bundle check` exit 0. `ruby -c web.rb` continues to report `Syntax OK` (exit 0) on the rebody re-check.

## Notes

- Dependency chain: `12factor app -> sinatra -> rack-session`.
- Lockfile-only change; no application source modifications were required.
- Bundler version in `BUNDLED WITH` advanced from `2.4.10` to `2.5.16` as a side effect of running `bundle update` under the local Bundler. Teams that pin Bundler in CI should confirm their CI image satisfies this floor; otherwise the pin can be reverted manually without affecting the security fix.
- No `pnpm.overrides` / `resolutions` equivalent is needed on the Bundler side, so the override registry section does not apply to this PR.

---
<sub>skill-sig: `26cfcbaf` · grackle-sig: `cc80d33f` · 3pp-skill canonical pipeline · 3pp-grackle babysit</sub>

<!-- 3pp-grackle-babysit:v1 run_id=babysit-2026-04-25-17-49-13 short_id=cc80d33f -->
