### PR TITLE
security: bump puma 6.6.0 -> 7.2.1 (GHSA-qpgp-93vx-g8v8)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'builder'
 gem 'thin'
 gem 'maruku'
 gem 'i18n'
-gem "puma", "~> 6.6"
+gem "puma", "~> 7.2"
 gem 'rack-ssl-enforcer'
 gem "rackup", "~> 2.2"
 gem 'rexml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,8 +11,8 @@ GEM
     logger (1.7.0)
     maruku (0.7.3)
     mustermann (3.1.1)
-    nio4r (2.7.4)
-    puma (6.6.0)
+    nio4r (2.7.5)
+    puma (7.2.1)
       nio4r (~> 2.0)
     rack (3.2.6)
     rack-protection (4.2.1)
@@ -48,7 +48,7 @@ DEPENDENCIES
   builder
   i18n
   maruku
-  puma (~> 6.6)
+  puma (~> 7.2)
   rack-ssl-enforcer
   rackup (~> 2.2)
   rexml


### PR DESCRIPTION
## Summary

Bumps [puma](https://github.com/puma/puma) from 6.6.0 to 7.2.1 to fix **GHSA-qpgp-93vx-g8v8** (CVE-2026-47736).

**Vulnerability:** Puma PROXY Protocol v1 Parser Allows Remote Memory Exhaustion
**Severity:** HIGH
**Vulnerable range:** >= 5.5.0, < 7.2.1
**Fix version:** 7.2.1

## Changes

- Updated `Gemfile` constraint: `~> 6.6` -> `~> 7.2`
- Regenerated `Gemfile.lock` via `bundle lock --update=puma`

## Risk Assessment

This is a major version bump (6.x -> 7.x). Puma 7 drops some deprecated configuration options and changes some defaults. Review the [Puma 7 upgrade guide](https://github.com/puma/puma/blob/master/docs/upgrade.md) for breaking changes relevant to this application.

## Verification

- `bundler-audit check` confirms GHSA-qpgp-93vx-g8v8 is resolved
- No other puma advisories remain
