### PR TITLE
fix(deps): bump rack-session to >=2.1.2 (GHSA-33qg-7wpp-89cq)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
       rack (>= 3.0.0, < 4)
-    rack-session (2.1.1)
+    rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
     rack-ssl-enforcer (0.2.9)


### PR DESCRIPTION
## Summary

Fixes 1 **CRITICAL** severity 3PP vulnerability in `rack-session` (GHSA-33qg-7wpp-89cq).

`rack-session` prior to 2.1.2 is affected by a session-fixation issue: when an application calls `Rack::Session::Abstract::SessionHash#destroy` without rotating session identifiers, the underlying session store can leave the old session ID usable by an attacker. Upgrading to 2.1.2 includes the upstream fix.

**Production risk:** Runtime — `rack-session` is a transitive dependency of `sinatra`, which serves the 12factor application's HTTP surface.

**Strategy:** lockfile-only transitive bump via `bundle lock --update=rack-session --conservative`

## Changes

### Gemfile.lock

Re-resolved `rack-session` from `2.1.1` to `2.1.2` (lockfile-only; no Gemfile change required):

```
-    rack-session (2.1.1)
+    rack-session (2.1.2)
```

Dependency chain: `12factor app -> sinatra -> rack-session`

## Version Selection

- Advisory floor (minimum patched): rack-session >= 2.1.2
- Applied: rack-session 2.1.2
- Rationale: exact advisory floor; minimal lockfile delta within 2.1.x.

## Vulnerabilities Fixed

| CVE/GHSA | Package | Severity | Fixed Version |
|----------|---------|----------|---------------|
| GHSA-33qg-7wpp-89cq | rack-session | critical | >=2.1.2 |

## Validation

- `bundler-audit check` baseline: GHSA-33qg-7wpp-89cq present (confirmed)
- `bundle lock --update=rack-session --conservative`: SUCCESS
- `bundler-audit check` post-fix: GHSA-33qg-7wpp-89cq cleared
- `ruby -c web.rb`: Syntax OK (exit 0)
- `bundle check`: exit 18 — host Ruby 3.2.2 vs Gemfile 3.3.5 (environmental mismatch, not a regression of the fix)

**Note:** CI should be used as the install validation gate due to host Ruby version mismatch.

## How to Test

```bash
# Confirm the lockfile now pins the patched version
grep 'rack-session' Gemfile.lock
# Expected: rack-session (2.1.2)

# Install and verify
bundle install

# Syntax check
bundle exec ruby -c web.rb

# Re-scan
bundle exec bundler-audit check
```
