### PR TITLE
Remove alignment from child and add it to upper level using rtl and l…

### DIFF
--- a/public/css/mobile.css
+++ b/public/css/mobile.css
@@ -43,7 +43,6 @@
   article ul, article ol {
     padding-left: 35px;
     padding-right: 10px;
-    text-align: left;
   }
   
   article table {
@@ -87,13 +86,11 @@
   article h1, article h2, article h3, article h6, article p, article table {
     padding-left: 15px;
     padding-right: 15px;
-    text-align: left;
   }
   
   article ul, article ol {
     padding-left: 35px;
     padding-right: 10px;
-    text-align: left;
   }
   
   article table {

--- a/public/css/screen.css
+++ b/public/css/screen.css
@@ -181,10 +181,12 @@ article img.full {
 
 article.rtl {
   direction: rtl;
+  text-align: right;
 }
 
 article.ltr {
   direction: ltr;
+  text-align: left;
 }
 
 .header-container {


### PR DESCRIPTION
Hi there.
To be clear:
Some RTL-specific styles for languages such as Persian were misplaced and needed to be moved to a higher level in the CSS hierarchy. With this change, LTR translations continue to load as before on mobile screens, while RTL languages are now right-aligned using the new styles.